### PR TITLE
docs: compress final assignment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,62 +1,63 @@
 # nlo-surprise-calendar
 
-Backend case assignment for Nederlandse Loterij: a concurrency-safe surprise calendar with fair prize distribution and persistent scratched-cell state.
+Backend case assignment for Nederlandse Loterij: a concurrency-safe surprise calendar with persistent state, a minimal Blazor UI, and PostgreSQL as the source of truth.
 
 ## Run
 
-Use Docker Compose as the primary local run path:
+Primary local run path:
 
 ```bash
 docker compose up --build
 ```
 
-Application URLs:
+Main URLs:
 
 - App: `http://localhost:8080`
-- Audit log view: `http://localhost:8080/audit`
-- API docs UI: `http://localhost:8080/docs`
+- Audit log: `http://localhost:8080/audit`
+- API docs: `http://localhost:8080/docs`
 - OpenAPI JSON: `http://localhost:8080/openapi/v1.json`
-- Live health: `http://localhost:8080/health/live`
-- Readiness health: `http://localhost:8080/health/ready`
-- Default game summary: `http://localhost:8080/api/bootstrap/default-game`
-- Grid state endpoint: `GET http://localhost:8080/api/games/default-game/grid-state`
-- Scratch endpoint: `POST http://localhost:8080/api/games/default-game/scratch`
-- Audit log endpoint: `GET http://localhost:8080/api/games/default-game/audit-attempts`
+- Readiness: `http://localhost:8080/health/ready`
+
+Main API routes:
+
+- Summary: `GET /api/bootstrap/default-game`
+- Grid state: `GET /api/games/default-game/grid-state`
+- Scratch: `POST /api/games/default-game/scratch`
+- Audit attempts: `GET /api/games/default-game/audit-attempts`
 
 UI flow:
 
-- enter a self-declared participant identifier
-- optionally cache it locally in the browser
-- clear it again via the visible `Log out` action
-- click a tile on the homepage grid to select a cell
-- confirm the scratch with the existing submit button
-- inspect the result panel for win, loss, duplicate-user, or duplicate-cell outcomes
-- inspect the audit log page to review accepted and rejected attempts with their recorded reason codes
-- open the API docs directly from the homepage when you want to inspect or exercise the endpoints
+1. Enter a self-declared participant identifier.
+2. Optionally cache it in the browser.
+3. Select a tile on the homepage grid.
+4. Confirm with the scratch button.
+5. Review the result panel or audit page.
 
-To stop the stack:
+Stop the stack with:
 
 ```bash
 docker compose down
 ```
 
-## Test
+## Validation
 
-Automated tests run from the repository root:
+Local validation:
 
 ```bash
-dotnet test -c Release
+dotnet restore NloSurpriseCalendar.slnx
+dotnet build NloSurpriseCalendar.slnx -c Release
+dotnet test NloSurpriseCalendar.slnx -c Release
 ```
 
-The integration tests use Testcontainers to start an isolated PostgreSQL instance, so Docker must be available when running the test suite.
+The test suite uses Testcontainers, so Docker must be available.
 
-A lightweight GitHub Actions workflow mirrors the same restore, build, and test sequence on pull requests to `main`.
+GitHub Actions mirrors the same restore, build, and test flow on pull requests to `main`.
 
 ## Review Trail
 
-The implementation process is tracked in GitHub issues, pull requests, and PR comments in addition to the repository docs. Reviewers can inspect that trail if they want to see the decision-making and review loop behind the code.
+The repo includes both implementation docs and the GitHub working trail. Reviewers can inspect issues, PRs, and PR comments if they want the decision history behind the code.
 
-## Documentation
+## Docs
 
 - [Design notes](docs/DESIGN.md)
 - [AI notes](docs/AI-NOTES.md)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ GitHub Actions mirrors the same restore, build, and test flow on pull requests t
 
 The repo includes both implementation docs and the GitHub working trail. Reviewers can inspect issues, PRs, and PR comments if they want the decision history behind the code.
 
+## Postmortem
+
+- Total time was about 4 hours, including a lunch break.
+- The strongest part of the assignment is the backend correctness story: transactional scratch handling, PostgreSQL constraints, audit logging, and database-backed tests.
+- Keeping the UI and identity model intentionally simple helped keep the timebox focused on the real risks.
+- Reviewer-facing extras like the audit view, OpenAPI docs, homepage grid, and CI were worth doing because they improved inspectability without changing the core design.
+- `#12` multi-game support was left out on purpose. It is a valid next step, but too large for this assignment window without weakening the core implementation.
+
 ## Docs
 
 - [Design notes](docs/DESIGN.md)

--- a/docs/AGENT-NOTES.md
+++ b/docs/AGENT-NOTES.md
@@ -2,136 +2,34 @@
 
 ## Purpose
 
-This file captures planning discussions with the coding agent so the reasoning is visible in the repository and does not depend on chat history.
+This file keeps a compact repository-side summary of planning discussions with the coding agent. It exists so the reasoning is preserved outside chat history.
 
-## 2026-03-12 Bootstrap Backlog Discussion
+## Bootstrap summary
 
-### User request summary
+Initial planning centered on a few explicit choices:
 
-Start with the bootstrap issue: derive a pragmatic implementation backlog from the assignment, reason explicitly before making changes, do not begin implementation yet, keep the backlog suitable for a 4-6 hour assignment, and keep all documentation except `README.md` under `docs/`.
+- treat the assignment as backend-first
+- keep the mandatory scope focused on correctness, persistence, concurrency, tests, and minimal UI
+- use ASP.NET Core, Blazor, PostgreSQL, and Docker Compose
+- avoid full authentication and use a self-declared participant identifier instead
+- enforce critical rules with database constraints plus transactions
 
-The user also asked that discussion with the agent be recorded in `AI-NOTES.md` to demonstrate deliberate use of AI support.
+## Backlog shaping
 
-Later in the same discussion, the user requested adding a repository `.gitignore` as part of the bootstrap work.
+The implementation plan was kept intentionally small:
 
-### Working assumptions
+- bootstrap and local run path
+- persistence and initialization
+- transactional scratch flow and audit trail
+- minimal UI
+- database-backed tests
+- final documentation
 
-- The assignment is backend-first.
-- Mandatory stack preferences are `.NET`, `ASP.NET Core`, `Blazor`, `Docker Compose`, and `PostgreSQL` unless a strong reason appears to change them.
-- The current repository is in bootstrap state and contains documentation only.
-- The goal of this issue is planning and backlog creation, not implementation.
+Stretch work was split into separate issues only after the mandatory scope was in place.
 
-### Scope reasoning
+## Why notes are split
 
-#### Mandatory scope
-
-- A persistent 100x100 surprise calendar with 10,000 cells.
-- Exactly 1 jackpot prize and exactly 100 consolation prizes.
-- A user may scratch exactly 1 cell.
-- A cell may be scratched exactly 1 time.
-- State must survive restarts.
-- The solution must behave correctly under concurrent requests.
-- A minimal web UI must exist.
-- The repository must include run instructions and design / AI usage documentation.
-
-#### Optional scope
-
-- Authentication beyond a simple user identifier strategy.
-- A polished UI or rich animations.
-- CI/CD beyond local validation.
-- Production hosting and infrastructure automation.
-- Advanced observability beyond basic health checks and logs.
-
-#### MVP vs stretch
-
-MVP should prove correctness:
-
-- ASP.NET Core application with scratch endpoint and minimal Blazor UI.
-- PostgreSQL-backed state.
-- Deterministic database initialization for prize distribution.
-- Concurrency-safe scratch transaction.
-- Automated tests for core rules and concurrency-sensitive paths.
-- Docker Compose for running app plus database locally.
-- `README.md`, `docs/DESIGN.md`, and this file.
-
-Stretch should remain clearly optional:
-
-- CI pipeline.
-- Extra health/diagnostic endpoints.
-- Better UX polish for the Blazor interface.
-- Additional admin/debug views.
-
-### Early design decisions that affect everything
-
-- Prize allocation strategy: pre-seed all winning cells during initialization rather than calculate them dynamically during scratch requests.
-- User identity strategy: start with an explicit self-declared user identifier passed from the UI/API to avoid spending assignment time on auth. Cache it client-side for convenience and provide a clear local "log out" action that removes the cached value.
-- Concurrency control strategy: enforce uniqueness in the database and perform the scratch flow in a transaction so correctness does not rely on in-memory locks.
-- Application shape: a single ASP.NET Core solution hosting API and Blazor UI keeps the timebox realistic.
-
-### Docker Compose and PostgreSQL impact
-
-- Docker Compose adds setup work but removes local environment ambiguity, which is valuable in an assignment.
-- PostgreSQL is the right place to enforce uniqueness constraints for "one scratch per user" and "one scratch per cell".
-- The backlog must include database initialization, migrations or schema setup, and seed behavior because persistence is not optional.
-- Compose should stay minimal: one app service and one PostgreSQL service.
-
-### Blazor impact
-
-- Blazor satisfies the "minimal web UI" requirement without adding a separate frontend stack.
-- The UI backlog should stay intentionally small: render the grid, submit one scratch, and show the result.
-- Shared .NET types between UI and backend can reduce time and complexity, which fits the assignment better than a split SPA architecture.
-
-### Concurrency risk analysis
-
-Main risk areas:
-
-- Two requests scratching the same cell at nearly the same time.
-- The same user attempting multiple scratches concurrently.
-- Prize counts becoming inconsistent if the scratch flow is not atomic.
-- Race conditions between application checks and persistence writes.
-
-Mitigation direction:
-
-- Use database constraints plus transactional updates as the correctness boundary.
-- Treat application-level checks as helpful, but not authoritative.
-- Add explicit tests for duplicate cell and duplicate user races.
-
-### Testing strategy
-
-Tests worth prioritizing in a 4-6 hour window:
-
-- Domain tests for prize distribution and rule validation.
-- Integration tests for scratch flow success and failure paths.
-- Concurrency-focused tests for same-cell and same-user contention.
-- Minimal UI smoke coverage only if time remains after backend correctness tests.
-
-Tests that are lower priority for the timebox:
-
-- Exhaustive UI interaction coverage.
-- Performance benchmarking beyond basic confidence.
-- Full end-to-end browser automation unless it is very cheap to add.
-
-### Required documentation and location
-
-- `README.md`: assignment summary, stack, and local run instructions.
-- `docs/DESIGN.md`: architecture, persistence strategy, concurrency approach, and trade-offs.
-- `docs/AI-NOTES.md`: AI-assisted reasoning, prompts, decisions, and backlog derivation trail.
-
-Any additional product or technical docs should also live under `docs/`.
-
-### Backlog shaping rationale
-
-The backlog should stay small and coherent. A pragmatic split for this assignment is:
-
-- bootstrap and solution skeleton
-- persistence and schema foundation
-- concurrency-safe scratch flow with API
-- minimal Blazor UI
-- test coverage for rules and concurrency
-- documentation and final polish
-
-This keeps the backlog reviewable without fragmenting the work into administrative noise.
-
-### Bootstrap hygiene note
-
-Adding a minimal `.gitignore` is justified during bootstrap because the repository already produced local `.NET` state (`.dotnet/`) while validating commands. Ignoring common local and build artifacts keeps the planning branch clean without affecting product scope.
+- `README.md` covers setup and usage
+- `docs/DESIGN.md` covers architecture and trade-offs
+- `docs/AI-NOTES.md` is reviewer-facing and concise
+- this file keeps the more process-oriented planning summary

--- a/docs/AI-NOTES.md
+++ b/docs/AI-NOTES.md
@@ -2,105 +2,51 @@
 
 ## Purpose
 
-This file is the candidate-facing summary of how AI support was used and which decisions it helped sharpen. It is intentionally concise and should read like notes for reviewers, not a raw chat transcript.
+This file summarizes how AI support was used. It is meant for reviewers, not as a raw transcript.
 
-## 2026-03-12 Bootstrap planning
+## How AI was used
 
-### Candidate note
+- turn the assignment into explicit mandatory vs optional scope
+- shape a backlog that fits the 4-6 hour timebox
+- pressure-test architecture and persistence choices before implementation
+- identify concurrency risks and the highest-value tests
+- help keep docs, issues, and PRs aligned with the actual implementation
 
-I explicitly chose not to spend assignment time on real authentication. The stronger signal in this case is correctness under concurrency, persistent state, and clear trade-off documentation.
-
-I also chose to log failed scratch attempts with explicit reason codes. For a lottery context, being able to explain rejected actions is worth the extra persistence work.
-
-I also kept tightening the demo based on what was actually visible while using it, instead of treating the first pass as finished. That included noticing when the page framing was too subtle and pushing for clearer presentation without expanding the core scope.
-
-After the mandatory scope was done, I prioritized reviewer visibility extras first. That is why the first stretch UI is an audit log view over more decorative or broader product features.
-
-When adding the optional grid, I chose to put it on the homepage and keep it select-then-confirm instead of immediate scratch-on-click. That kept the UI more inspectable and reduced accidental actions during a demo.
-I also caught a CSS regression during the OpenAPI work instead of hand-waving it away, and I chose to simplify the site colors when readability suffered. That was the right trade-off for an assignment demo: plain and legible beats decorative styling.
-I kept the CI stretch goal intentionally small as well: just mirror the existing local restore, build, and test commands on pull requests instead of adding a more ambitious pipeline.
-
-### What AI was used for
-
-- turning the assignment text into explicit mandatory scope versus optional scope
-- shaping an MVP backlog that fits a 4-6 hour implementation window
-- identifying early architecture choices that affect the whole solution
-- identifying concurrency risks and the tests needed to prove correctness
-- deciding where assignment documentation should live in the repository
-- pressure-testing persistence modeling choices before implementation starts
-
-### Key decisions taken
+## Main decisions
 
 - Keep the assignment backend-first and optimize for correctness over polish.
-- Use a single ASP.NET Core solution with Blazor for the minimal UI to avoid split-stack overhead.
-- Use PostgreSQL as the persistence boundary and Docker Compose for a reproducible local setup.
-- Use straight SQL with `Npgsql` instead of Entity Framework for persistence.
-- Rely on database constraints plus transactions for concurrency-sensitive rules instead of in-memory locking.
-- Record both accepted and rejected scratch attempts in an audit-friendly way, while keeping successful claims as the authoritative invariant table.
+- Use one ASP.NET Core app with Blazor instead of a split frontend/backend stack.
+- Use PostgreSQL plus Docker Compose as the standard local setup.
+- Use straight SQL with `Npgsql` so schema rules and transaction boundaries stay explicit.
+- Treat the database as the final authority for concurrency-sensitive rules.
 - Use a self-declared participant identifier instead of full authentication.
-- Keep the backlog small and coherent: bootstrap, persistence, scratch flow/API, UI, tests, and documentation/polish.
-- Cache the participant identifier locally for convenience and provide a visible clear-identity or log-out action.
-- Use milestones to separate mandatory assignment scope from optional stretch work, instead of carrying a separate priority-label system.
-- Use xUnit plus Testcontainers-backed PostgreSQL integration tests instead of relying on fake repositories or in-memory database substitutes.
-- Keep the UI intentionally small: a row/column picker, cached identifier, log-out action, and clear result messaging instead of a bigger frontend build-out.
-- Split broad optional backlog items into specific GitHub issues once the mandatory scope is done, so stretch work stays reviewable and easy to prioritize.
-- Remove optional backlog items again when they are only plumbing and do not stand on their own as useful reviewer-facing scope.
-- Add a reviewer-facing audit log view on top of the persisted attempt trail before taking on broader optional features like a live grid or multi-game support.
-- Keep the optional grid driven by persisted backend state, but reveal only scratched cells so unclaimed prize positions stay hidden.
-- For the API docs stretch goal, use built-in ASP.NET Core OpenAPI generation plus Scalar instead of Swagger-specific tooling.
-- Add a lightweight regression test when a concrete UI integration issue is found, even if the assignment does not justify a full browser-test stack.
-- Keep CI aligned with the local validation commands instead of inventing a separate pipeline story.
+- Cache that identifier locally and provide a visible local log-out action.
+- Record both successful claims and rejected attempts for auditability.
+- Use Testcontainers-backed PostgreSQL tests instead of fake repositories or in-memory substitutes.
+- Prefer reviewer-facing optional work first: audit view, docs UI, homepage grid, then CI.
 
-### Why those decisions fit the assignment
+## Why those decisions fit
 
-- The mandatory requirements are mostly about persistence, fairness, and concurrency safety.
-- Docker Compose plus PostgreSQL adds some setup cost but makes the local story cleaner and more convincing for review.
-- Straight SQL keeps schema, constraints, initialization, and transactional behavior explicit, which is more valuable here than ORM convenience.
-- Blazor is sufficient for a minimal UI while keeping implementation effort focused on the backend.
-- Concurrency correctness is the highest-risk part of the assignment, so it deserves the strongest design and testing focus.
-- In a lottery context, storing failed attempts and their reasons improves explainability when users dispute outcomes.
-- Real PostgreSQL-backed tests are more credible here because the important invariants are enforced by database constraints and transactions.
-- Full authentication would consume time without materially improving the core assignment proof points.
-- Caching the identifier improves the demo flow, while a clear local sign-out keeps the simplification honest and understandable.
-- A compact Blazor UI is enough to demonstrate the end-to-end flow without spending assignment time on a production-style calendar frontend.
-- Once the mandatory scope is complete, the best next extras are the ones that improve reviewer visibility with the least architectural churn.
-- The audit trail already existed in the data model, so exposing it as a simple read-only view is a high-signal stretch goal with low implementation risk.
-- That same rule also means dropping optional issues that are better folded into a stronger parent feature instead of preserving them as standalone backlog noise.
-- Built-in OpenAPI plus a homepage-linked docs UI improves reviewer visibility with low implementation risk and better matches modern .NET direction than adding Swagger.
-- When presentation gets in the way of clarity, simplify it. The assignment benefits more from readable UI than from visual styling.
-- A homepage grid is a stronger demo than row/column inputs, but select-then-confirm is still the safer interaction than one-click scratching.
-- A minimal CI workflow adds reviewer confidence without changing the local-first development model.
+- The assignment is mainly about persistence, fairness, and concurrency safety.
+- Full authentication would consume time without improving the strongest proof points.
+- Straight SQL is easier to defend here than ORM abstraction.
+- Real PostgreSQL-backed tests are more credible because the key invariants are enforced in the database.
+- Readable reviewer-facing extras add more value than larger stretch architecture.
 
-### Notes for implementation
-
-- Seed prize allocation up front rather than calculating winners during scratch requests.
-- Do not pre-store all 10,000 non-winning cells if the model can derive "empty" cells safely from the configured grid size plus stored prize/scratch state.
-- Keep persistence explicit with hand-written SQL instead of adding EF abstraction during the assignment timebox.
-- Keep successful claims authoritative, but add append-only audit records for rejected attempts too.
-- Start with a simple user identifier approach instead of full authentication.
-- Cache that identifier in the browser for convenience and provide a visible way to clear it.
-- Keep the MVP UI to a row/column selector plus result panel rather than rendering all 10,000 cells.
-- Keep Docker Compose as the primary documented local run path.
-- Keep future multi-game support in mind in the persistence model, but track it as separate work.
-- Preserve an audit-friendly data trail for prize allocation and scratch events.
-- Prioritize integration tests for same-cell and same-user contention.
-- Use Testcontainers for the database-backed tests so the suite validates the actual PostgreSQL constraint behavior without depending on a manually prepared local database.
-- Keep `docs/DESIGN.md` intentionally concise and within roughly two pages.
-- Keep `README.md` for setup and keep all other product/technical notes under `docs/`.
-- Prefer optional work in this order: reviewer visibility first, then inspectability, then bigger architectural expansion.
-- Keep optional reviewer views read-only and grounded in persisted data rather than building demo-only mock state.
-- If interactive API docs are added, make them reachable from the homepage instead of leaving them as an undocumented route.
-- If a grid is added, derive it from a backend board-state endpoint and avoid leaking unrevealed prize positions.
-- Keep CI to restore, build, and test unless there is a clear reason to add more pipeline complexity.
-
-### What I want a reviewer to see
+## Candidate notes
 
 - I made scope cuts intentionally instead of accidentally omitting work.
 - I used AI to pressure-test trade-offs and backlog shape, not to avoid design responsibility.
-- I kept the design honest by documenting where the solution is intentionally simplified.
-- I kept the GitHub tracker aligned with the actual scope split: mandatory work versus optional showcase work.
-- I used GitHub issues, PRs, and PR comments as part of the working record, so reviewers can inspect both the code and the decision trail.
+- I kept simplifying when usability or readability got worse during review.
+- I kept the GitHub tracker and repo docs aligned so the reasoning is inspectable.
 
-## Supporting detail
+## Implementation notes
 
-The fuller planning trail is kept separately in `docs/AGENT-NOTES.md` so `docs/AI-NOTES.md` remains suitable as assignment-facing notes.
+- Prize allocation is seeded up front.
+- Empty cells are derived rather than pre-stored.
+- Scratch operations are transactional.
+- Successful claims stay authoritative; attempt events stay append-only.
+- The homepage grid is backed by persisted board state and only reveals scratched cells.
+- CI intentionally mirrors the local restore, build, and test workflow without adding extra pipeline scope.
+
+The fuller planning trail is kept separately in `docs/AGENT-NOTES.md`.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,79 +1,57 @@
 # Design Notes
 
-## Status
+## Goal
 
-Bootstrap planning document. This file captures the initial design direction and constraints before implementation starts.
+Build a backend-first surprise calendar that stays correct under concurrency, persists state across restarts, and includes a minimal but usable web UI.
 
-## Assignment goals
+## Core rules
 
-Build a backend-first surprise calendar that is correct under concurrency, persists state across restarts, and includes a minimal UI.
+- The board has 10,000 cells.
+- There is exactly 1 jackpot prize.
+- There are exactly 100 consolation prizes.
+- A participant may scratch exactly 1 cell.
+- A cell may be scratched exactly 1 time.
 
-## Proposed technical shape
+## Technical shape
 
 - Single ASP.NET Core solution.
-- Minimal API or controller endpoints for scratch operations and read models.
-- Blazor-based UI hosted in the same application.
+- Blazor UI hosted in the same app.
+- Minimal HTTP endpoints for summary, scratch, audit, docs, and grid state.
 - PostgreSQL as the system of record.
-- Docker Compose for local orchestration.
+- Docker Compose for the standard local run path.
 
-## Core domain constraints
+## Persistence and concurrency
 
-- Calendar contains exactly 10,000 cells.
-- Exactly 1 jackpot prize exists.
-- Exactly 100 consolation prizes exist.
-- Each user may scratch exactly one cell.
-- Each cell may be scratched exactly once.
+- Straight SQL via `Npgsql`, not Entity Framework.
+- Startup-managed schema initialization for the MVP.
+- Prize allocation is seeded up front.
+- Empty cells are derived from board dimensions plus stored winning and scratched positions.
+- The scratch flow is transactional.
+- Database constraints enforce one scratch per participant and one scratch per cell.
+- Successful claims are authoritative.
+- Accepted and rejected attempts are also written to an append-only audit trail.
 
-## Persistence direction
+## UI scope
 
-- Initialize calendar state and prize allocation in PostgreSQL.
-- Use straight SQL via `Npgsql`, not Entity Framework, so schema rules, initialization, and transaction boundaries stay explicit.
-- Use startup-managed SQL initialization recorded in a `schema_versions` table as the migration strategy for the MVP.
-- Avoid storing all 10,000 non-winning cells if the system can derive empty cells safely from game dimensions plus stored winning/scratched positions.
-- Use database constraints to protect uniqueness rules.
-- Prefer short transactional writes plus uniqueness constraints for scratch operations rather than optimistic retries as the primary correctness mechanism.
-- Keep scratch operations transactional.
-- Persist enough data to reconstruct current state after restart without relying on in-memory caches.
-- Keep auditability explicit: prize allocation and scratch outcomes should be explainable from persisted records in the database.
-- Separate authoritative scratch claims from append-only attempt-event auditing so rejected requests can be explained without weakening core invariants.
-- Leave room in the model for future multi-game support, but keep that feature out of the MVP.
+- Self-declared participant identifier instead of full authentication.
+- Client-side identifier cache plus explicit local log out.
+- Homepage grid with click-to-select and explicit confirm.
+- Only scratched cells reveal outcomes; hidden prize positions are not leaked.
+- Audit page for reviewer-facing inspectability.
 
-## Concurrency direction
+## Timebox choices
 
-- Treat the database as the final authority for conflicting writes.
-- Favor transactional scratch handling over in-process locking.
-- Design acceptance tests around conflict scenarios, not only the happy path.
-
-## UI direction
-
-- Keep the Blazor UI minimal and functional.
-- Support entering a self-declared user identifier, selecting a cell, and showing the result.
-- Use a homepage grid with click-to-select plus explicit confirm, rather than one-click scratching.
-- Keep the board read model limited to scratched cells so hidden prize positions are not leaked.
-- Cache the identifier client-side for convenience and provide a clear "log out" or "clear identity" action that removes it from local storage.
-- Avoid UI work that does not improve the demonstration of correctness.
-- Prefer reviewer-facing inspectability work, such as an audit log view, before larger optional UI expansions.
-
-## Identity approach
-
-- Do not implement full authentication in the MVP.
-- Treat the submitted user identifier as the participant key enforced by the backend.
-- Make it explicit in the UI and docs that this is a demo-time simplification, not secure identity verification.
-- Optimize for clarity and low implementation cost rather than pretending weak authentication is real security.
-
-## Timebox trade-offs
-
-Prioritize:
+Prioritized:
 
 - correctness
-- explainability
 - persistence
+- explainability
 - concurrency safety
 - clear docs
 
-De-prioritize unless time remains:
+Explicitly de-prioritized:
 
-- visual polish
-- advanced observability
-- CI/CD
-- deployment automation
+- real authentication
+- visual polish beyond readability
+- production infrastructure
+- larger multi-game expansion


### PR DESCRIPTION
## What changed
- tightened README.md into a shorter run-and-review guide
- compressed docs/DESIGN.md into a smaller set of scan-friendly sections
- reduced docs/AI-NOTES.md to reviewer-facing decisions instead of a long narrative
- trimmed docs/AGENT-NOTES.md into a compact process summary

## Validation
- dotnet restore NloSurpriseCalendar.slnx
- dotnet build NloSurpriseCalendar.slnx -c Release
- dotnet test NloSurpriseCalendar.slnx -c Release

## Known limitations
- this change is documentation-only; it does not change application behavior
- some historical detail was intentionally removed in favor of readability

Fixes #7